### PR TITLE
Asynchronously perform database operations on queue, using transactions.

### DIFF
--- a/src/fmdb/FMDatabaseQueue.h
+++ b/src/fmdb/FMDatabaseQueue.h
@@ -158,6 +158,13 @@
 
 - (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block;
 
+/** Asynchronously perform database operations on queue, using transactions.
+ 
+ @param block The code to be run on the queue of `FMDatabaseQueue`
+ */
+
+- (void)inTransactionAsync:(void (^)(FMDatabase *db, BOOL *rollback))block;
+
 /** Synchronously perform database operations on queue, using deferred transactions.
 
  @param block The code to be run on the queue of `FMDatabaseQueue`


### PR DESCRIPTION
Synchronous transaction on queue hangs ui if some insertion/updation is performed on large no of rows.
To avoid ui hang because of synchronous transaction I have added a method named "inTransactionAsync" which perform database operations asynchronously.
